### PR TITLE
Update phantomas command path in analyze.js

### DIFF
--- a/analyze.js
+++ b/analyze.js
@@ -14,7 +14,7 @@ var validate = require('./validate');
 function buildCommand(options){
   validate(options);
 
-  var command = __dirname + '/node_modules/.bin/phantomas ' + options.url;
+  var command = 'phantomas ' + options.url;
 
   command += ' --engine ' + options.engine;
   command += ' --runs ' + options.runs;


### PR DESCRIPTION
Removes path to phantomas node module so the global instance is used instead. The inclusion of the node variable __dirname was forcing the task to look for a phantomas dependency within it's home directory instead of the projects node modules directory.
